### PR TITLE
update buildimage debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-trixie AS build
 
 ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@2fe62df6
 ENV GO111MODULE=on
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 ARG GPHOTOS_CDP_VERSION=$DEFAULT_GPHOTOS_CDP_VERSION
 RUN go install $GPHOTOS_CDP_VERSION
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ENV \
     LANG=C.UTF-8 \


### PR DESCRIPTION
test sync with trixie image:

```shell
$ docker compose up --build
[+] Building 161.0s (15/15) FINISHED
 => [internal] load local bake definitions                                                                                                                                                                 0.0s
 => => reading from stdin 676B                                                                                                                                                                             0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                       0.0s
 => => transferring dockerfile: 1.17kB                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/debian:trixie-slim                                                                                                                                      1.2s
 => [internal] load metadata for docker.io/library/golang:1.25-trixie                                                                                                                                      1.5s
 => [internal] load .dockerignore                                                                                                                                                                          0.0s
 => => transferring context: 2B                                                                                                                                                                            0.0s
 => [build 1/2] FROM docker.io/library/golang:1.25-trixie@sha256:bb4cb22775a49166723091fdc87bc97b30799b6dcd5868f9be27021cb7baf1f8                                                                         44.0s
 => => resolve docker.io/library/golang:1.25-trixie@sha256:bb4cb22775a49166723091fdc87bc97b30799b6dcd5868f9be27021cb7baf1f8                                                                                0.0s
 => => sha256:bb4cb22775a49166723091fdc87bc97b30799b6dcd5868f9be27021cb7baf1f8 9.05kB / 9.05kB                                                                                                             0.0s
 => => sha256:93829d2530defccd1184b0bedb7f21fdda98a53d052835ad34667241ba5742d5 2.32kB / 2.32kB                                                                                                             0.0s
 => => sha256:bc4d5657862713f14fceb288b425c209632d4d572ec14193c9feb260a6e5ebab 3.04kB / 3.04kB                                                                                                             0.0s
 => => sha256:e3143549f2b8b3ad8d79efdc47824641c6771796b3770f3c637a38aabd2b3462 25.62MB / 25.62MB                                                                                                          10.6s
 => => sha256:13cc39f8244ac66bf1dd9149e1da421ab1bbc80d612dc14fe368753e7be17b33 49.29MB / 49.29MB                                                                                                           4.4s
 => => sha256:72e8e93b0d018b135d833207c6feaba205653ac52e0a80d214477ec0de239dee 67.78MB / 67.78MB                                                                                                          14.4s
 => => extracting sha256:13cc39f8244ac66bf1dd9149e1da421ab1bbc80d612dc14fe368753e7be17b33                                                                                                                  3.7s
 => => sha256:c64bdd8f08413e7a99d843e0aac4b8f8c9bee0337f253701a760d0eed37fb577 102.09MB / 102.09MB                                                                                                        26.6s
 => => sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d 60.15MB / 60.15MB                                                                                                          21.2s
 => => extracting sha256:e3143549f2b8b3ad8d79efdc47824641c6771796b3770f3c637a38aabd2b3462                                                                                                                  1.8s
 => => sha256:1fcf5793032101bdf2c33d082ff752b5eb54273e9186d1bd58b9a1cf27eed27a 126B / 126B                                                                                                                14.7s
 => => extracting sha256:72e8e93b0d018b135d833207c6feaba205653ac52e0a80d214477ec0de239dee                                                                                                                  6.3s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                                                                                  15.0s
 => => extracting sha256:c64bdd8f08413e7a99d843e0aac4b8f8c9bee0337f253701a760d0eed37fb577                                                                                                                  6.9s
 => => extracting sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d                                                                                                                  9.3s
 => => extracting sha256:1fcf5793032101bdf2c33d082ff752b5eb54273e9186d1bd58b9a1cf27eed27a                                                                                                                  0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                                                                                  0.0s
 => [internal] load build context                                                                                                                                                                          0.0s
 => => transferring context: 151B                                                                                                                                                                          0.0s
 => [stage-1 1/5] FROM docker.io/library/debian:trixie-slim@sha256:a347fd7510ee31a84387619a492ad6c8eb0af2f2682b916ff3e643eb076f925a                                                                       11.6s
 => => resolve docker.io/library/debian:trixie-slim@sha256:a347fd7510ee31a84387619a492ad6c8eb0af2f2682b916ff3e643eb076f925a                                                                                0.0s
 => => sha256:96b963b72bb1b4e1dee4dc437fbc67c236ab6c1918a6990a5f844eecad76e284 451B / 451B                                                                                                                 0.0s
 => => sha256:d7ecded7702a5dbf6d0f79a71edc34b534d08f3051980e2c948fba72db3197fc 29.78MB / 29.78MB                                                                                                           8.9s
 => => sha256:a347fd7510ee31a84387619a492ad6c8eb0af2f2682b916ff3e643eb076f925a 8.97kB / 8.97kB                                                                                                             0.0s
 => => sha256:ae614fe11cb373155bf26b938154c34bed87aa701f2f55a4ef03f872e4314ab0 1.02kB / 1.02kB                                                                                                             0.0s
 => => extracting sha256:d7ecded7702a5dbf6d0f79a71edc34b534d08f3051980e2c948fba72db3197fc                                                                                                                  2.5s
 => [stage-1 2/5] RUN apt-get update && apt-get install -y         apt-transport-https         ca-certificates         curl         cron         exiftool         jq         wget         sudo     --no  124.2s
 => [build 2/2] RUN go install github.com/akop/gphotos-cdp@35cc86cf26228c786ca17729c5f179738009f19c                                                                                                       48.9s
 => [stage-1 3/5] COPY --from=build /go/bin/gphotos-cdp /usr/bin/                                                                                                                                          0.2s
 => [stage-1 4/5] COPY src ./app/                                                                                                                                                                          0.1s
 => [stage-1 5/5] RUN chmod +x /app/*.sh                                                                                                                                                                   0.4s
 => exporting to image                                                                                                                                                                                    22.6s
 => => exporting layers                                                                                                                                                                                   22.5s
 => => writing image sha256:b5c4c26e29fb019750669a0697e09f1084dcfac5c197785dc3d0e18be8ea5ba8                                                                                                               0.0s
 => => naming to docker.io/library/gphotos-sync-gphotos-sync                                                                                                                                               0.0s
 => resolving provenance for metadata file                                                                                                                                                                 0.0s
[+] Running 2/2
 ✔ gphotos-sync-gphotos-sync  Built                                                                                                                                                                        0.0s
 ✔ Container gphotos-sync     Recreated                                                                                                                                                                   10.7s
Attaching to gphotos-sync
gphotos-sync  | usermod: no changes
gphotos-sync  | {"level":"info","message":"running with user uid: 1000 and user gid: 1000","dt":"2025-11-06T04:46:04Z"}
gphotos-sync  | {"level":"info","message":"scheduling cron job for: 0 * * * *","dt":"2025-11-06T04:46:04Z"}
gphotos-sync  | {"level":"info","message":"starting sync.sh, pid: 56","dt":"2025-11-06T05:00:01Z"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:02.165Z","message":"syncing files at root dir https://photos.google.com"}
gphotos-sync  | {"level":"debug","dt":"2025-11-06T05:00:28.162Z","message":"buildDirCache for /download done in in 25.989128158s"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:28.162Z","message":"session dir: /tmp/gphotos-cdp"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:28.164Z","message":"starting Chrome browser"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:29.033Z","message":"Browser version: Chrome/142.0.7444.134"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:29.033Z","message":"starting authentication..."}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:34.552Z","message":"successfully authenticated"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:00:34.556Z","message":"using locale en"}
gphotos-sync  | {"level":"debug","dt":"2025-11-06T05:00:35.24Z","message":"page loaded, most recent item in the feed is: AF1QipMqHmvpafmZWnOkT6eJ7Ffi_y_0ISNT9byDCgOz"}
gphotos-sync  | {"level":"debug","dt":"2025-11-06T05:00:35.28Z","message":"location: https://photos.google.com/"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:01:36.212Z","message":"so far: downloaded 0 (0 in queue), progress: 24.30% (3645/14998), estimated remaining: 11353 (3m7s)"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:02:36.213Z","message":"so far: downloaded 0 (0 in queue), progress: 54.68% (8913/16299), estimated remaining: 7386 (1m39s)"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:03:36.213Z","message":"so far: downloaded 0 (0 in queue), progress: 77.09% (13193/17114), estimated remaining: 3921 (53s)"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:04:36.214Z","message":"so far: downloaded 0 (0 in queue), progress: 92.58% (16648/17982), estimated remaining: 1334 (19s)"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:05:16.837Z","message":"checking for removed files"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:05:16.837Z","message":"in total: synced 18374 items, downloaded 0, progress: 100.00%"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:05:16.869Z","message":"folders found for 1 local photos that were not found in this sync. Checking google photos to confirm they are not there"}
gphotos-sync  | {"level":"debug","dt":"2025-11-06T05:05:17.626Z","message":"photo ******** was not in original sync, but is still present on google photos, it might be in the trash"}
gphotos-sync  | {"level":"info","dt":"2025-11-06T05:05:17.692Z","message":"Done in 5m15.527364861s"}
gphotos-sync  | {"level":"info","message":"completed sync.sh, pid: 56","dt":"2025-11-06T05:05:17Z"}
```