### PR TITLE
sync.sh: retry gphotos-cdp on transient failures

### DIFF
--- a/src/sync.sh
+++ b/src/sync.sh
@@ -8,27 +8,53 @@ if [ -n "$HEALTHCHECK_ID" ]; then
   curl -sS -X POST -o /dev/null "$HEALTHCHECK_HOST/$HEALTHCHECK_ID/start"
 fi
 
-set -e
-
 PROFILE_DIR="${PROFILE_DIR:-/tmp/gphotos-cdp}"
 DOWNLOAD_DIR="${DOWNLOAD_DIR:-/download}"
 WORKER_COUNT=${WORKER_COUNT:-6}
 LOGLEVEL=${LOGLEVEL:-info}
+SYNC_MAX_RETRIES=${SYNC_MAX_RETRIES:-3}
+SYNC_RETRY_BACKOFF=${SYNC_RETRY_BACKOFF:-60}
 GPHOTOS_CDP_ARGS="-profile \"$PROFILE_DIR\" -headless -json -loglevel $LOGLEVEL -removed -workers $WORKER_COUNT $GPHOTOS_CDP_ARGS -run /app/postdl.sh"
 
-rm -f $PROFILE_DIR/Singleton*
+# Retry gphotos-cdp on non-zero exit. gphotos-cdp has a deadman that
+# panics if no enumeration progress for 20 min — typically caused by
+# Chrome's DOM interaction wedging on a particular item or Google
+# throttling. A fresh invocation = fresh Chrome, which clears the
+# wedge. Each retry resumes from .lastdone so progress isn't lost.
+# Configurable: SYNC_MAX_RETRIES (default 3), SYNC_RETRY_BACKOFF (60s).
+run_cdp_with_retry() {
+  local cmd="$1"
+  local attempt=0
+  local rc=0
+  while [ $attempt -lt $SYNC_MAX_RETRIES ]; do
+    attempt=$((attempt + 1))
+    rm -f $PROFILE_DIR/Singleton*
+    info "gphotos-cdp attempt $attempt/$SYNC_MAX_RETRIES"
+    if eval "$cmd"; then
+      info "gphotos-cdp completed cleanly on attempt $attempt"
+      return 0
+    fi
+    rc=$?
+    if [ $attempt -lt $SYNC_MAX_RETRIES ]; then
+      info "gphotos-cdp exited with $rc; sleeping ${SYNC_RETRY_BACKOFF}s before retry"
+      sleep $SYNC_RETRY_BACKOFF
+    fi
+  done
+  info "gphotos-cdp failed after $SYNC_MAX_RETRIES attempts (last exit code $rc)"
+  return $rc
+}
 
 if [ -n "$ALBUMS" ]; then
   for ALBUM in $(echo $ALBUMS | tr ',' ' '); do
     ALBUM_DL_DIR="$DOWNLOAD_DIR/$(basename "$ALBUM")"
     if [ "$ALBUM" = "ALL" ]; then
-      eval gphotos-cdp -dldir "$ALBUM_DL_DIR" $GPHOTOS_CDP_ARGS
+      run_cdp_with_retry "gphotos-cdp -dldir \"$ALBUM_DL_DIR\" $GPHOTOS_CDP_ARGS" || exit $?
     else
-      eval gphotos-cdp -dldir "$ALBUM_DL_DIR" $GPHOTOS_CDP_ARGS -album $ALBUM
+      run_cdp_with_retry "gphotos-cdp -dldir \"$ALBUM_DL_DIR\" $GPHOTOS_CDP_ARGS -album $ALBUM" || exit $?
     fi
   done
 else
-  eval gphotos-cdp -dldir "$DOWNLOAD_DIR" $GPHOTOS_CDP_ARGS
+  run_cdp_with_retry "gphotos-cdp -dldir \"$DOWNLOAD_DIR\" $GPHOTOS_CDP_ARGS" || exit $?
 fi
 
 info "completed sync.sh, pid: $$"


### PR DESCRIPTION
## Summary

gphotos-cdp has a hard-coded deadman that calls `panic("no new items processed for 20 minutes, stopping sync")` whenever the enumeration counter doesn't advance for 20 consecutive 60s ticks. In practice this fires whenever Chrome's DOM interaction wedges on a single item — e.g. the `could not press download button` path retries hit the attempt limit and the worker stalls, taking the enumeration loop with it.

The sync.sh wrapper's `set -e` then bails the whole script, the healthcheck stays red, and the next cron tick is hours away.

This PR wraps the cdp invocation in a retry-with-backoff loop. Each fresh attempt is a fresh Chrome process which clears whatever DOM/JS state caused the wedge, and gphotos-cdp resumes from `.lastdone` so accumulated progress isn't lost.

## Behavior

- New env knobs (defaults preserve current single-shot timing for users who'd rather have cron handle retries):
  - `SYNC_MAX_RETRIES=3`
  - `SYNC_RETRY_BACKOFF=60` (seconds between attempts)
- Each attempt clears leftover `Singleton*` lock files (moved the inline `rm` into the retry function).
- Healthcheck semantics unchanged: `/start` ping fires once per sync.sh invocation; success ping only on a clean attempt; a run that exhausts retries returns the last `gphotos-cdp` exit code so the healthcheck stays red.
- `set -e` removed in favor of explicit `|| exit $?` propagation, so the retry loop can observe non-zero exits without unwinding the script.

## Motivating failure mode (observed 2026-05-25)

```
worker 1: tried to request download 3 times, giving up now
worker 1: requesting download (backup method)
[20 min of "so far: downloaded 0 (2 in queue), progress: 52.23% (65407/125219)"]
panic: no new items processed for 20 minutes, stopping sync
```

The previous worker-1 wedge tied up enumeration; cdp panicked at the 20-min mark; sync.sh exited; healthcheck stayed red; next cron was 8 hours away.

After this PR: same scenario triggers attempt 2, fresh Chrome resumes from `.lastdone`, downloads continue. Three attempts × ~20 min worst-case wedge = at most ~1 hour to drain transient wedges within a single cron run.

## Test plan

- [ ] `bash -n src/sync.sh` (syntax check) — passes locally
- [ ] Build the Docker image, run with `SYNC_MAX_RETRIES=1` and a deliberately broken `gphotos-cdp` invocation (e.g. wrong path) → verify single attempt logged + exit code propagates
- [ ] Run with default settings against a real Google Photos account, force a Chrome wedge mid-run, verify attempt 2 fires after 60s and picks up from `.lastdone`