### PR TITLE
Dockerfile: bump gphotos-cdp pin to 4ec1ede5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25-trixie AS build
 
-ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@2fe62df6
+ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@4ec1ede5
 ENV GO111MODULE=on
 
 ARG GPHOTOS_CDP_VERSION=$DEFAULT_GPHOTOS_CDP_VERSION


### PR DESCRIPTION
Pulls in the two robustness fixes merged on gphotos-cdp master:

- **[#10](https://github.com/spraot/gphotos-cdp/pull/10)** (4c4c902 + 868dbf7): replace deadman `panic()` with a clean `cancel()` + `globalErrChan` exit; reset the no-progress counter when *either* enumeration or `downloadedCount` advances. Downloads-only stalls are now caught; queue-draining tail no longer trips the watchdog.
- **[#11](https://github.com/spraot/gphotos-cdp/pull/11)** (673faf1): imageId fallback when `lastNode`'s NodeID has been removed from the DOM by Google's virtualized scroll. The scroll anchor recovers via the photo's stable permalink suffix instead of silently failing the pointer-equality dedupe.

Combined with [#32](https://github.com/spraot/gphotos-sync/pull/32)'s `sync.sh` retry-with-backoff already on main, the transient `"could not press download button"` / 20-min-no-progress failure pattern is now self-healing within a single sync.sh invocation.

## Test plan
- [ ] Build the image with `docker build .` (or via `go install $DEFAULT_GPHOTOS_CDP_VERSION` directly) and verify the resulting `gphotos-cdp` binary contains the new symbols / log lines (e.g. grep for "scroll anchor recovered by imageId").
- [ ] Run against a real account for a few hours; verify any deadman-fires produce a clean error message + non-zero exit instead of a goroutine panic stack.