### PR TITLE
Dockerfile: bump gphotos-cdp pin to 049ce4d6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25-trixie AS build
 
-ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@b126b68
+ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@049ce4d6
 ENV GO111MODULE=on
 
 ARG GPHOTOS_CDP_VERSION=$DEFAULT_GPHOTOS_CDP_VERSION


### PR DESCRIPTION
Pulls in [spraot/gphotos-cdp#12](https://github.com/spraot/gphotos-cdp/pull/12) — bounds the chromedp.Run calls in `requestDownloadBackup` and `pressButton` with 5s `context.WithTimeout`.

Fixes the wedge where a poisoned item that falls through to the backup download method silently hangs the worker (and through the unbuffered jobChan, the entire sync) because Chrome stops ACKing DevTools-protocol messages and the worker's outer ctx has no deadline. After this bump, the worker errors-out within 5s instead of hanging, and the existing `startDownload` 120s `timeoutTimer` + this repo's retry-with-backoff (PR #32) can take it from there.