### PR TITLE
Dockerfile: bump gphotos-cdp pin to d12df766

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.25-trixie AS build
 
-ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@049ce4d6
+ENV DEFAULT_GPHOTOS_CDP_VERSION=github.com/spraot/gphotos-cdp@d12df766
 ENV GO111MODULE=on
 
 ARG GPHOTOS_CDP_VERSION=$DEFAULT_GPHOTOS_CDP_VERSION


### PR DESCRIPTION
Pulls in [spraot/gphotos-cdp#13](https://github.com/spraot/gphotos-cdp/pull/13): bounds the `chromedp.Run` in `getPhotoData`'s videoStillProcessing check with 5s `context.WithTimeout` and wraps timeout error as `errCouldNotLoadPhoto` so the existing worker skip-and-continue path handles it.

Same shape as [#12](https://github.com/spraot/gphotos-cdp/pull/12) (which bounded the equivalent calls in `requestDownloadBackup` + `pressButton`), in a different code path.